### PR TITLE
Adding --shutdown-instance-timer-sec to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ python generate_custom_image.py \
     out-of-the-box Dataproc image. This image must be a valid Dataproc image.
     The format of the partial image URI is the following:
     "projects/<project_id>/global/images/<image_name>".
+*   **--shutdown-instance-timer-sec**: The time to wait in seconds before shutting down the VM
+      instance. This value may need to be increased if your init script
+      generates a lot of output on stdout. If not specified, the default value
+      of 300 seconds will be used.
 *   **--dry-run**: Dry run mode which only validates input and generates
     workflow script without creating image. Disabled by default.
 


### PR DESCRIPTION
I noticed that the --shutdown-instance-timer-sec argument in the python script was exposed but not shown in the README file as one of the optional argument.