### PR TITLE
add network tags to vm creation

### DIFF
--- a/custom_image_utils/args_parser.py
+++ b/custom_image_utils/args_parser.py
@@ -146,6 +146,13 @@ def parse_args(args):
       If the default network does not exist in your project, please specify
       a valid network interface.""")
   parser.add_argument(
+      "--tags",
+      type=str,
+      required=False,
+      default="",
+      help="""(Optional) Network tags used to launch the VM instance that builds
+      the custom image.""")
+  parser.add_argument(
       "--subnetwork",
       type=str,
       required=False,

--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -84,6 +84,7 @@ function main() {{
       {network_flag} \
       {subnetwork_flag} \
       {no_external_ip_flag} \
+      {tags_flag} \
       --machine-type={machine_type} \
       --disk=auto-delete=yes,boot=yes,mode=rw,name={image_name}-install \
       {accelerator_flag} \
@@ -160,6 +161,8 @@ class Generator:
     elif self.args["network"]:
       self.args["network_flag"] = "--network={network}".format(**self.args)
       self.args["subnetwork_flag"] = ""
+    if self.args["tags"]:
+      self.args["tags_flag"] = "--tags={tags}".format(**self.args)
     if self.args["service_account"]:
       self.args[
         "service_account_flag"] = "--service-account={service_account}".format(


### PR DESCRIPTION
for firewall rule purposes, sometimes a network tag is required on the vm creation. This adds that option